### PR TITLE
Improve vocab filtering

### DIFF
--- a/longformer/simplification.py
+++ b/longformer/simplification.py
@@ -391,6 +391,7 @@ class Simplifier(pl.LightningModule):
         parser.add_argument("--max_epochs", type=int, default=100000, help="Maximum number of epochs (will stop training even if patience for early stopping has not been reached).")
         parser.add_argument("--early_stopping_metric", type=str, default='rougeL', help="Metric to be used for early stopping: vloss, rouge1, rouge2, rougeL, rougeLsum, bleu")
         parser.add_argument("--patience", type=int, default=10, help="Patience for early stopping.")
+        parser.add_argument("--min_delta", type=float, default=0.0, help="Minimum change in the monitored quantity to qualify as an improvement.")
         parser.add_argument("--lr_reduce_patience", type=int, default=8, help="Patience for LR reduction in Plateau scheduler.")
         parser.add_argument("--lr_reduce_factor", type=float, default=0.5, help="Learning rate reduce factor for Plateau scheduler.")
         parser.add_argument("--disable_checkpointing", action='store_true', help="No logging or checkpointing")
@@ -444,7 +445,7 @@ def main(args):
     # if args.early_stopping_metric == 'val_loss':
     if args.early_stopping_metric == 'vloss':
         model.lr_mode='min'
-    early_stop_callback = EarlyStopping(monitor=args.early_stopping_metric, min_delta=0.00, patience=args.patience, verbose=True, mode=model.lr_mode) # metrics: val_loss, bleu, rougeL
+    early_stop_callback = EarlyStopping(monitor=args.early_stopping_metric, min_delta=args.min_delta, patience=args.patience, verbose=True, mode=model.lr_mode) # metrics: val_loss, bleu, rougeL
     
     custom_checkpoint_path = "checkpoint{{epoch:02d}}_{{{}".format(args.early_stopping_metric )
     custom_checkpoint_path += ':.5f}'

--- a/longformer/simplify.py
+++ b/longformer/simplify.py
@@ -159,7 +159,7 @@ class InferenceSimplifier(pl.LightningModule):
 
         if not self.args.output_to_json:
 
-            generated_strs = self.tokenizer.batch_decode(generated_ids.tolist(), skip_special_tokens=True)
+            generated_strs = self.tokenizer.batch_decode(generated_ids.tolist(), skip_special_tokens=not self.args.keep_special_tokens)
             with open(self.args.translation, 'a') as f:
                 for sample in generated_strs:
                     f.write(sample + "\n")
@@ -173,9 +173,9 @@ class InferenceSimplifier(pl.LightningModule):
             # if running inference with self.args.batch_size
             # > 1, we need to make sure we pair the correct input sequence
             # with the correct returned hypotheses.
-            batch_hyp_strs = self.tokenizer.batch_decode(generated_ids.sequences.tolist(), skip_special_tokens=True)
+            batch_hyp_strs = self.tokenizer.batch_decode(generated_ids.sequences.tolist(), skip_special_tokens=not self.args.keep_special_tokens)
             batch_hyp_scores = generated_ids.sequences_scores.tolist()
-            batch_source_strs = self.tokenizer.batch_decode(input_ids.tolist(), skip_special_tokens=True)
+            batch_source_strs = self.tokenizer.batch_decode(input_ids.tolist(), skip_special_tokens=not self.args.keep_special_tokens)
 
             generated_strs = []
 
@@ -297,6 +297,7 @@ class InferenceSimplifier(pl.LightningModule):
         parser.add_argument("--beam_size", type=int, default=4, help="Beam size for inference when testing/validating. Default: 4.")
         parser.add_argument("--test_percent_check", default=1.00, type=float, help='Percent of test data used')
         parser.add_argument("--global_attention_indices", type=int, nargs='+', default=[-1], required=False, help="List of indices of positions with global attention for longformer attention. Supports negative indices (-1 == last non-padding token). Default: [-1] == last source token (==lang_id) .")
+        parser.add_argument("--keep_special_tokens", default=False, action="store_true", help="If true, do not skip special tokens.")
 
         parser.add_argument("--output_to_json", default=False, action="store_true", help='If true, decoding output is a verbose JSONL containing, src, tgt, and scored model output hyps')
         

--- a/scripts/filter_foreign.py
+++ b/scripts/filter_foreign.py
@@ -92,7 +92,7 @@ class UnwantedSeq(Exception):
     pass
 
 
-def filter_foreign_characters(unfiltered):
+def filter_foreign_characters(unfiltered, return_set=False):
     filtered = list()
 
     for line in unfiltered:
@@ -113,7 +113,8 @@ def filter_foreign_characters(unfiltered):
             continue
             
     filtered = set(filtered)
-    filtered = sorted(filtered)
+    if not return_set:
+        filtered = sorted(filtered)
     return filtered
 
                                                                   

--- a/scripts/frequency_filter.py
+++ b/scripts/frequency_filter.py
@@ -47,7 +47,7 @@ def main(filter_data_dir, vocab_dir, filename, n_list):
     freq_list = get_freq_list(filter_data_dir)
     with open(os.path.join(vocab_dir, filename), 'r') as infile:
         complete = infile.readlines()
-    unfiltered = filter_foreign_characters(complete)
+    unfiltered = filter_foreign_characters(complete, return_set=True)
     for n in n_list:
         filtered = filter_by_frequency(unfiltered, freq_list, n)
         outfilename = os.path.join(vocab_dir, '{}.{}k'.format(filename, int(n/1000)))

--- a/scripts/frequency_filter.py
+++ b/scripts/frequency_filter.py
@@ -110,7 +110,7 @@ def main(args: argparse.Namespace):
         create_raw_vocab(freq_list, args.output_dir, args.output_prefix)
     if args.filtered and args.output_dir and args.output_prefix:
         create_filtered_vocab(freq_list, args.output_dir, args.output_prefix)
-    if (args.vocab_sizes and args.complete_vocab and args.output_dir and args.output_prefix):
+    if args.vocab_sizes and args.complete_vocab and args.output_dir and args.output_prefix:
         complete = args.complete_vocab.readlines()
         unfiltered = filter_foreign_characters(complete, return_set=True)
         for n in args.vocab_sizes:

--- a/scripts/frequency_filter.py
+++ b/scripts/frequency_filter.py
@@ -5,7 +5,7 @@
 import sys
 import os            
             
-from filter import filter_foreign_characters
+from filter_foreign import filter_foreign_characters
 
 
 def get_freq_list(filter_data_dir):

--- a/scripts/frequency_filter.py
+++ b/scripts/frequency_filter.py
@@ -2,23 +2,58 @@
 # -*- coding: utf-8 -*-
 
 
-import sys
-import os            
-            
+import argparse
+from pathlib import Path
+
 from filter_foreign import filter_foreign_characters
 
 
-def get_freq_list(filter_data_dir):
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--filter-files",
+        type=argparse.FileType("r"),
+        nargs="+",
+        help="Files from which to create a frequency list",
+        metavar="PATH",
+    )
+    parser.add_argument(
+        "--complete-vocab",
+        type=argparse.FileType("r"),
+        help="File containing the complete vocabulary to filter",
+        metavar="PATH",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Output directory for filtered vocabularies",
+        metavar="PATH",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        type=str,
+        help="File prefix for output files",
+        metavar="PATH",
+    )
+    parser.add_argument(
+        "--vocab-size",
+        type=int,
+        nargs="+",
+        help="Vocabulary size of the output",
+        metavar="PATH",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def get_freq_list(frequency_files):
     def by_value(item):
         return item[1]
-        
+
     freq_dict = dict()
     freq_list = list()
-    # frequency_files = os.listdir(filter_data_dir)
-    frequency_files = ['APA_capito_webcorpus.spm']
     for file in frequency_files:
-        with open(os.path.join(filter_data_dir, file), 'r') as infile:
-            lines = infile.readlines()
+        lines = file.readlines()
         for line in lines:
             tokens = line.split()
             for token in tokens:
@@ -26,39 +61,36 @@ def get_freq_list(filter_data_dir):
                     freq_dict[token] += 1
                 else:
                     freq_dict[token] = 1
-    
+
     for k, v in sorted(freq_dict.items(), key=by_value, reverse=True):
         freq_list.append(k)
     return freq_list
-    
-    
+
+
 def filter_by_frequency(unfiltered, freq_list, n):
     filtered = list()
-    
+
     for c in freq_list:
-        if len(filtered) >= n: break
+        if len(filtered) >= n:
+            break
         if c in unfiltered:
             filtered.append(c)
-    
+
     return sorted(filtered)
-    
-    
-def main(filter_data_dir, vocab_dir, filename, n_list):
-    freq_list = get_freq_list(filter_data_dir)
-    with open(os.path.join(vocab_dir, filename), 'r') as infile:
-        complete = infile.readlines()
+
+
+def main(args: argparse.Namespace):
+    freq_list = get_freq_list(args.filter_files)
+    complete = args.complete_vocab.readlines()
     unfiltered = filter_foreign_characters(complete, return_set=True)
-    for n in n_list:
+    for n in args.vocab_size:
         filtered = filter_by_frequency(unfiltered, freq_list, n)
-        outfilename = os.path.join(vocab_dir, '{}.{}k'.format(filename, int(n/1000)))
+        outfilename = args.output_dir / '{}.{}k'.format(args.output_prefix, int(n/1000))
         with open(outfilename, 'w') as outfile:
             for token in filtered:
                 outfile.write(token + '\n')
 
-                
+
 if __name__ == '__main__':
-    filter_data_dir = '../data/frequency_data'
-    vocab_dir = '../data/vocabulary'
-    filename = 'all.spm.uniq'
-    n_list = [20000, 23000, 25000, 27000, 30000, 35000]
-    main(filter_data_dir, vocab_dir, filename, n_list)
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
This PR adds a cli interface to the vocabulary filtering scripts and adds the possibility of creating raw (unfiltered) and unicode-filtered vocabs from a number of subword-segmented text files.
Additionally, the two cli arguments `--min_delta` and `--keep_special_tokens` were added to the training and inference scripts, respectively.

**Changes:**
- Add `--min_delta` cli arg to the training script.
- Add `--keep_special_tokens` to the inference script.
- Fix an import and speed up membership test for vocabulary creation.
- Add a cli interface for creating vocabularies of all kinds (raw, unicode-filtered and frequency-filtered).