### PR TITLE
Pin rouge_score version to 0.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ test-tube==0.7.5
 nltk==3.5
 numpy==1.19.5
 nlp
-rouge_score
+rouge_score==0.0.4
 requests
 sacrebleu
 datasets==1.2.1


### PR DESCRIPTION
This small PR pins the `rouge_score` version in the requirements to `0.0.4`, which is the newest version that is compatible with the rest of the `longmbart` code.

This allows us to avoid the following Error when training:
```
Traceback (most recent call last):
  File "/net/cephfs/data/nispri/FFG-Projekt/ats-experiments/environments/longmbart/venv-longmbart/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/net/cephfs/data/nispri/FFG-Projekt/ats-experiments/environments/longmbart/venv-longmbart/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/net/cephfs/data/nispri/FFG-Projekt/ats-experiments/environments/longmbart/venv-longmbart/lib/python3.8/site-packages/longformer/simplification.py", line 11, in <module>
    from rouge_score import rouge_scorer
ModuleNotFoundError: No module named 'rouge_score'
```